### PR TITLE
Add ContentLoadingProgressDialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Name | License | Demo
 [Animated Circle Loading View](https://github.com/jlmd/AnimatedCircleLoadingView) | [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0) | <img src="/art/AnimatedCircleLoadingView.gif" width="49%">
 [AndroidFillableLoaders](https://github.com/JorgeCastilloPrz/AndroidFillableLoaders) | [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0) | <img src="/art/AndroidFillableLoaders.gif" width="49%"> <img src="/art/AndroidFillableLoaders2.gif" width="49%">
 [spots-dialog](https://github.com/d-max/spots-dialog) | [MIT](http://opensource.org/licenses/MIT) | <img src="/art/spots_dialog.gif" width="49%">
+[ContentLoadingProgressDialog](https://github.com/tasomaniac/ContentLoadingProgressDialog) | [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0) | NONE
 
 Menu
 ======================

--- a/pages/Progress.md
+++ b/pages/Progress.md
@@ -16,3 +16,4 @@ Name | License | Demo
 [AndroidFillableLoaders](https://github.com/JorgeCastilloPrz/AndroidFillableLoaders) | [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0) | <img src="/art/AndroidFillableLoaders.gif" width="49%"> <img src="/art/AndroidFillableLoaders2.gif" width="49%">
 [spots-dialog](https://github.com/d-max/spots-dialog) | [MIT](http://opensource.org/licenses/MIT) | <img src="/art/spots_dialog.gif" width="49%">
 [AVLoadingIndicatorView](https://github.com/81813780/AVLoadingIndicatorView) | [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0) | <img src="/art/AVLoadingIndicatorView.gif" width="49%">
+[ContentLoadingProgressDialog](https://github.com/tasomaniac/ContentLoadingProgressDialog) | [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0) | NONE


### PR DESCRIPTION
ContentLoadingProgressDialog is added without an image. 

The library is look exactly like the normal ProgressDialog. 
The cool feature is that it is not displayed at all if it is dismissed in 500 millisecond to avoid UI flashes. 
